### PR TITLE
Fix conflicting peer dependency caused by `npm audit fix --force`

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "backend",
             "devDependencies": {
                 "axios": "^0.21",
                 "laravel-mix": "^6.0.6",
@@ -10093,19 +10092,19 @@
             }
         },
         "node_modules/serverless-domain-manager": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/serverless-domain-manager/-/serverless-domain-manager-5.1.5.tgz",
-            "integrity": "sha512-yzoQTvPRuBodvf+rFYl4CJQ8cBQVa1kpHvJzzIyiIRM8fxI4oYeJuR2R5TU9vvY4fKjrsg6UUk8ndgG8Eui5Vw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/serverless-domain-manager/-/serverless-domain-manager-5.8.0.tgz",
+            "integrity": "sha512-AaSmJAc51aEvIaj7RHS3C1apkf1EJ2g9C5rDM+5I7EMlNJmj8u+gKc+7v7vtae17YEdGB3nrXoUYknJ3Gaxl4g==",
             "dev": true,
             "dependencies": {
-                "aws-sdk": "^2.948.0",
-                "chalk": "^4.1.1"
+                "aws-sdk": "^2.1064.0",
+                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": ">=12"
             },
             "peerDependencies": {
-                "serverless": "1 || 2"
+                "serverless": "<4"
             }
         },
         "node_modules/serverless/node_modules/ajv": {
@@ -19760,13 +19759,13 @@
             }
         },
         "serverless-domain-manager": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/serverless-domain-manager/-/serverless-domain-manager-5.1.5.tgz",
-            "integrity": "sha512-yzoQTvPRuBodvf+rFYl4CJQ8cBQVa1kpHvJzzIyiIRM8fxI4oYeJuR2R5TU9vvY4fKjrsg6UUk8ndgG8Eui5Vw==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/serverless-domain-manager/-/serverless-domain-manager-5.8.0.tgz",
+            "integrity": "sha512-AaSmJAc51aEvIaj7RHS3C1apkf1EJ2g9C5rDM+5I7EMlNJmj8u+gKc+7v7vtae17YEdGB3nrXoUYknJ3Gaxl4g==",
             "dev": true,
             "requires": {
-                "aws-sdk": "^2.948.0",
-                "chalk": "^4.1.1"
+                "aws-sdk": "^2.1064.0",
+                "chalk": "^4.1.2"
             }
         },
         "setimmediate": {


### PR DESCRIPTION
## Summary

There was a peer dependency conflict due to the below upgrade.

- #123

To resolve the issue, run `npm upgrade serverless-domain-manager`

## Error

```shell
npm ERR! While resolving: serverless-domain-manager@5.1.5
npm ERR! Found: serverless@3.18.1
npm ERR! node_modules/serverless
npm ERR!   dev serverless@"^3.18.1" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer serverless@"1 || 2" from serverless-domain-manager@5.1.5
npm ERR! node_modules/serverless-domain-manager
npm ERR!   dev serverless-domain-manager@"^5.1.5" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: serverless@2.72.3
npm ERR! node_modules/serverless
npm ERR!   peer serverless@"1 || 2" from serverless-domain-manager@5.1.5
npm ERR!   node_modules/serverless-domain-manager
npm ERR!     dev serverless-domain-manager@"^5.1.5" from the root project
```