### PR TITLE
Update the RDS `subnet_ids` attribute

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -25,7 +25,7 @@ module "db" {
   create_random_password = true
   port                   = "3306"
 
-  subnet_ids             = module.vpc.private_subnets
+  subnet_ids             = module.vpc.database_subnets
   vpc_security_group_ids = [module.security_group.security_group_id]
 
   # Parameter group


### PR DESCRIPTION
## Summary

This is one of the approaches for resolving the following error.

```terraform
│ Error: Error creating DB Instance: InvalidParameterCombination: The DB instance and EC2 security group are in different VPCs. The DB instance is in vpc-071755cdf3bd1a374 and the EC2 security group is in vpc-054d5779d010989b8
│ 	status code: 400, request id: eef8c4c0-fab0-433a-b517-1aacc2c7d0f3
│ 
│   with module.db.module.db_instance.aws_db_instance.this[0],
│   on .terraform/modules/db/modules/db_instance/main.tf line 26, in resource "aws_db_instance" "this":
│   26: resource "aws_db_instance" "this" {
│ 
```

## References

- https://github.com/terraform-aws-modules/terraform-aws-rds/blob/master/examples/complete-mysql/main.tf
- https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/master/main.tf
  - `resource "aws_db_subnet_group" "database"`