### PR TITLE
Revert "Update the RDS subnet_ids attribute #128"

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -26,7 +26,7 @@ module "db" {
   port                   = "3306"
 
   create_db_subnet_group = true
-  subnet_ids             = module.vpc.database_subnets
+  subnet_ids             = module.vpc.private_subnets
   vpc_security_group_ids = [module.security_group.security_group_id]
 
   # Parameter group


### PR DESCRIPTION
##  Problem

The following error occurred.

```terraform
module.db.module.db_subnet_group.aws_db_subnet_group.this[0]: Creating...
╷
│ Error: Error creating DB Subnet Group: InvalidSubnet: Subnet IDs are required.
│ 	status code: 400, request id: 1b31961b-9395-48cc-b1c6-6bf3f9a31fd4
│ 
│   with module.db.module.db_subnet_group.aws_db_subnet_group.this[0],
│   on .terraform/modules/db/modules/db_subnet_group/main.tf line 8, in resource "aws_db_subnet_group" "this":
│    8: resource "aws_db_subnet_group" "this" {
│ 
```
