### PR TITLE
Fix the issue that `sail artisan` doesn't work and Japanese is not output

### DIFF
--- a/backend/.env.local.example
+++ b/backend/.env.local.example
@@ -1,6 +1,6 @@
 WWWUSER=1000
 WWWGROUP=1000
-WORKING_DIR=/var/www/html
+PROJECT_DIR=/var/www/html
 BACKEND_DIR=backend
 
 APP_NAME=Miwataru

--- a/backend/docker-compose.extend.yml
+++ b/backend/docker-compose.extend.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
   laravel.test:
     volumes:
-      - '..:${WORKING_DIR}'
+      - '..:${PROJECT_DIR}'
       - 'vscode-extensions:/home/sail/.vscode-server/extensions'
 volumes:
   vscode-extensions:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       WORKING_DIR: '${WORKING_DIR}'
       BACKEND_DIR: '${BACKEND_DIR}'
       LARAVEL_SAIL: 1
-    working_dir: '${WORKING_DIR}'
+    # Starting directory in the container
+    working_dir: '${WORKIN_DIR}/${BACKEND_DIR}'
     volumes:
       - '.:${WORKING_DIR}/${BACKEND_DIR}'
       - 'vendor:${WORKING_DIR}/${BACKEND_DIR}/vendor'

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -8,22 +8,22 @@ services:
       # ref. `Dockerfile`.`ARG`
       args:
         WWWGROUP: '${WWWGROUP}'
-        WORKDIR: '${WORKING_DIR}'
+        WORKDIR: '${PROJECT_DIR}'
     image: sail-8.1/app
     ports:
       - '${APP_PORT:-80}:80'
     # ref. `start-container`, `supervisord.conf`
     environment:
       WWWUSER: '${WWWUSER}'
-      WORKING_DIR: '${WORKING_DIR}'
+      PROJECT_DIR: '${PROJECT_DIR}'
       BACKEND_DIR: '${BACKEND_DIR}'
       LARAVEL_SAIL: 1
     # Starting directory in the container
-    working_dir: '${WORKIN_DIR}/${BACKEND_DIR}'
+    working_dir: '${PROJECT_DIR}/${BACKEND_DIR}'
     volumes:
-      - '.:${WORKING_DIR}/${BACKEND_DIR}'
-      - 'vendor:${WORKING_DIR}/${BACKEND_DIR}/vendor'
-      - 'node_modules:${WORKING_DIR}/${BACKEND_DIR}/node_modules'
+      - '.:${PROJECT_DIR}/${BACKEND_DIR}'
+      - 'vendor:${PROJECT_DIR}/${BACKEND_DIR}/vendor'
+      - 'node_modules:${PROJECT_DIR}/${BACKEND_DIR}/node_modules'
     networks:
       - sail
     depends_on:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - '${APP_PORT:-80}:80'
     # ref. `start-container`, `supervisord.conf`
     environment:
+      LANG: 'C.UTF-8'
       WWWUSER: '${WWWUSER}'
       PROJECT_DIR: '${PROJECT_DIR}'
       BACKEND_DIR: '${BACKEND_DIR}'

--- a/backend/docker/8.1/supervisord.conf
+++ b/backend/docker/8.1/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=/usr/bin/php -d variables_order=EGPCS %(ENV_WORKING_DIR)s/%(ENV_BACKEND_DIR)s/artisan serve --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS %(ENV_PROJECT_DIR)s/%(ENV_BACKEND_DIR)s/artisan serve --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout
@@ -16,13 +16,13 @@ stderr_logfile_maxbytes=0
 [program:laravel-worker]
 process_name=%(program_name)s_%(process_num)02d
 numprocs=8
-command=php %(ENV_WORKING_DIR)s/%(ENV_BACKEND_DIR)s/artisan queue:work --sleep=3 --tries=3 --max-time=3600
+command=php %(ENV_PROJECT_DIR)s/%(ENV_BACKEND_DIR)s/artisan queue:work --sleep=3 --tries=3 --max-time=3600
 autostart=true
 autorestart=true
 stopasgroup=true
 killasgroup=true
 user=sail
 redirect_stderr=true
-stdout_logfile=%(ENV_WORKING_DIR)s/%(ENV_BACKEND_DIR)s/storage/logs/worker.log
-stderr_logfile=%(ENV_WORKING_DIR)s/%(ENV_BACKEND_DIR)s/storage/logs/worker_error.log
+stdout_logfile=%(ENV_PROJECT_DIR)s/%(ENV_BACKEND_DIR)s/storage/logs/worker.log
+stderr_logfile=%(ENV_PROJECT_DIR)s/%(ENV_BACKEND_DIR)s/storage/logs/worker_error.log
 stopwaitsecs=3600


### PR DESCRIPTION
## Problems

- While the starting directory in the container was `/var/www/html`, `artisan` didn't exist there
- The default locale in the Laravel container was POSIX