### PR TITLE
To make `artisan config:cache` available, replace `env()` outside config files with `config()`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,9 @@ jobs:
       - name: Directory Permissions
         run: chmod -R 777 storage bootstrap/cache
 
+      - name: Cache Bootstrap Files
+        run: php artisan optimize
+
       - name: Install Serverless globally
         run: npm install -g serverless
 

--- a/backend/app/Actions/Fortify/UpdateUserPassword.php
+++ b/backend/app/Actions/Fortify/UpdateUserPassword.php
@@ -19,7 +19,7 @@ class UpdateUserPassword implements UpdatesUserPasswords
      */
     public function update($user, array $input)
     {
-        if ($user->email === env('GUEST_EMAIL')) {
+        if ($user->email === config('fortify.guest.email')) {
             abort(403);
         }
 

--- a/backend/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/backend/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -18,7 +18,7 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
      */
     public function update($user, array $input)
     {
-        if ($user->email === env('GUEST_EMAIL')) {
+        if ($user->email === config('fortify.guest.email')) {
             abort(403);
         }
 

--- a/backend/app/Http/Middleware/Authenticate.php
+++ b/backend/app/Http/Middleware/Authenticate.php
@@ -18,8 +18,8 @@ class Authenticate extends Middleware
         if (!$request->expectsJson()) {
             $path = $request->session()->get('url.intended');
             $url = $path
-                ? url(env('SPA_URL') . '/login' . '?dest=' . $path)
-                : url(env('SPA_URL') . '/login');
+                ? url(config('fortify.home') . '/login' . '?dest=' . $path)
+                : url(config('fortify.home') . '/login');
             return $url;
         }
     }

--- a/backend/app/Providers/AuthServiceProvider.php
+++ b/backend/app/Providers/AuthServiceProvider.php
@@ -53,7 +53,7 @@ class AuthServiceProvider extends ServiceProvider
         ResetPassword::toMailUsing(function ($notifiable, string $token) {
             $email = $notifiable->getEmailForPasswordReset();
             $queryParams = '?token=' . $token . '&email=' . $email;
-            $url = env('SPA_URL') . '/reset-password' . $queryParams;
+            $url = config('fortify.home') . '/reset-password' . $queryParams;
 
             return (new MailMessage())
                 ->subject(Lang::get('Reset Password Notification'))

--- a/backend/app/Providers/TelescopeServiceProvider.php
+++ b/backend/app/Providers/TelescopeServiceProvider.php
@@ -55,7 +55,11 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
     protected function gate()
     {
         Gate::define('viewTelescope', function ($user) {
-            return in_array($user->email, [env('ADMIN_EMAIL')]);
+            return in_array(
+                $user->email,
+                config('telescope.user.emails'),
+                true,
+            );
         });
     }
 }

--- a/backend/config/fortify.php
+++ b/backend/config/fortify.php
@@ -140,4 +140,20 @@ return [
         //     'confirmPassword' => true,
         // ]),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Test User
+    |--------------------------------------------------------------------------
+    |
+    | The email-validated test user data that doesn't want to be updated.
+    | This user should be created before the application starts.
+    |
+    */
+
+    'guest' => [
+        'name' => env('GUEST_NAME', 'Guest'),
+        'email' => env('GUEST_EMAIL', 'test@example.com'),
+        'password' => env('GUEST_PASSWORD', 'password'),
+    ],
 ];

--- a/backend/config/telescope.php
+++ b/backend/config/telescope.php
@@ -78,6 +78,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Telescope Authenticated Users
+    |--------------------------------------------------------------------------
+    |
+    | The following array lists the "watchers" that will be registered with
+    | Telescope. The watchers gather the application's profile data when
+    | a request or task is executed. Feel free to customize this list.
+    |
+    */
+
+    'user' => [
+        'emails' => [env('ADMIN_EMAIL')],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Allowed / Ignored Paths & Commands
     |--------------------------------------------------------------------------
     |

--- a/backend/database/seeders/UserSeeder.php
+++ b/backend/database/seeders/UserSeeder.php
@@ -18,10 +18,17 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
+        // > Once the configuration has been cached, the .env file will not be loaded.
+        // > https://laravel.com/docs/9.x/configuration#configuration-caching
+        //
+        //`env()` returns `null`, after running `php artisan config:cache`.
+        // Use `config()` instead. To remove the cache, run `php artisan config:clear`
+        // (The cached config is stored in `bootstrap/cache/config.php`)
+
         self::$guestUser = User::factory()->create([
-            'name' => env('GUEST_NAME'),
-            'email' => env('GUEST_EMAIL'),
-            'password' => Hash::make(env('GUEST_PASSWORD')),
+            'name' => config('fortify.guest.name'),
+            'email' => config('fortify.guest.email'),
+            'password' => Hash::make(config('fortify.guest.password')),
         ]);
 
         self::$anotherUser = User::factory()->create();

--- a/backend/tests/TestCase.php
+++ b/backend/tests/TestCase.php
@@ -17,12 +17,11 @@ abstract class TestCase extends BaseTestCase
     {
         parent::setUp();
 
-        $this->routePrefix =
-            env('API_ROUTE_PREFIX', '/api/') . env('API_VERSION', 'v1');
+        $this->routePrefix = config('fortify.prefix');
 
         $this->guestUser = User::factory()->create([
-            'name' => env('GUEST_NAME'),
-            'email' => env('GUEST_EMAIL'),
+            'name' => config('fortify.guest.name'),
+            'email' => config('fortify.guest.email'),
         ]);
 
         $this->otherUser = User::factory()->create();


### PR DESCRIPTION
## Summary

1. For the performance enhancement, the configuration caching can't be used.
2. Once the config cached, `env()` outside config files won't work.
3. To avoid this problem, replace `env()` with `config()`.
4. Finally, use `php artisan config:cache` in CD pipeline.

> https://laravel.com/docs/9.x/configuration#configuration-caching