### PR TITLE
Add environment variables required when running `artisan optimize`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,8 @@ jobs:
             --path provider.environment \
             | sed "s/: /=/" >> .env
         env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           APP_KEY: ${{ secrets.APP_KEY }}
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
 


### PR DESCRIPTION
## Problem

- Same as: #141 
  (against: #139)


## Error

```shell
Error retrieving credentials from the instance profile metadata service. (Error retrieving metadata token) {"exception":"[object] (Aws\\Exception\\CredentialsException(code: 0)
```