### PR TITLE
Remove a stage specific `.env` to make serverless read `.env`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,8 @@ jobs:
             --stage dev \
             --path provider.environment \
             | sed "s/: /=/" >> .env
+          # https://www.serverless.com/framework/docs/environment-variables#support-for-env-files
+          rm .env.dev
         env:
           APP_KEY: ${{ secrets.APP_KEY }}
           ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}


### PR DESCRIPTION
## Problem

- Same as: #143 
  (against: #139)


## Error

```shell
Cannot resolve variable at "provider.environment.APP_KEY": Value not found at "env" source,
```