### PR TITLE
Add a missing environment variable to `serverless.yml`

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -60,6 +60,7 @@ provider:
 
   # https://www.serverless.com/framework/docs/providers/aws/guide/variables
   environment:
+    AWS_DEFAULT_REGION: ${env:AWS_DEFAULT_REGION}
     APP_NAME: ${env:APP_NAME}
     APP_KEY: ${env:APP_KEY}
     APP_URL: https://api.${ssm:/${env:APP_NAME}/${sls:stage}/DOMAIN_NAME}


### PR DESCRIPTION
## Problem

- `.env` generated at #141 doesn't contain `AWS_DEFAULT_REGION.` Thus Serverless cannot read the value.

## Error

```shell
Cannot resolve variable at "provider.region": Value not found at "env" source
```