### PR TITLE
Remove the reserved `AWS_DEFAULT_REGION` from `serverless.yml`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,6 +146,10 @@ jobs:
             --stage dev \
             --path provider.environment \
             | sed "s/: /=/" >> .env
+          serverless print \
+            --stage dev \
+            --path provider.region \
+            | sed "s/: /=/" >> .env
           # https://www.serverless.com/framework/docs/environment-variables#support-for-env-files
           rm .env.dev
         env:

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -60,7 +60,6 @@ provider:
 
   # https://www.serverless.com/framework/docs/providers/aws/guide/variables
   environment:
-    AWS_DEFAULT_REGION: ${env:AWS_DEFAULT_REGION}
     APP_NAME: ${env:APP_NAME}
     APP_KEY: ${env:APP_KEY}
     APP_URL: https://api.${ssm:/${env:APP_NAME}/${sls:stage}/DOMAIN_NAME}


### PR DESCRIPTION
## Problem

- Same as: #145 

## Error

```shell
Lambda was unable to configure your environment variables because the environment variables you have provided contains reserved keys that are currently not supported for modification. Reserved keys used in this request: AWS_DEFAULT_REGION
```