### PR TITLE
Remove the deprecated in `serverless.yml` and Add a property to show deprecated details

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -19,8 +19,6 @@ custom:
     autoDomain: true
 
 provider:
-  # https://www.serverless.com/framework/docs/deprecations#default-providerlambdahashingversion
-  lambdaHashingVersion: 20201221
   name: aws
   region: ${opt:region, env:AWS_DEFAULT_REGION}
   stage: ${opt:stage}

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,5 +1,8 @@
 service: ${env:APP_NAME}
 
+# https://www.serverless.com/framework/docs/deprecations#notification-mode
+deprecationNotificationMode: warn
+
 # https://www.serverless.com/framework/docs/deprecations#automatic-loading-environment-variables-from-env-and-envstage-files
 useDotenv: true
 

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -3,9 +3,6 @@ service: ${env:APP_NAME}
 # https://www.serverless.com/framework/docs/deprecations#automatic-loading-environment-variables-from-env-and-envstage-files
 useDotenv: true
 
-# https://www.serverless.com/framework/docs/deprecations#configvalidationmode-error-will-be-new-default
-configValidationMode: error
-
 # https://www.serverless.com/framework/docs/providers/aws/guide/variables#reference-variables-using-the-ssm-parameter-store
 variablesResolutionMode: 20210326
 

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -3,9 +3,6 @@ service: ${env:APP_NAME}
 # https://www.serverless.com/framework/docs/deprecations#automatic-loading-environment-variables-from-env-and-envstage-files
 useDotenv: true
 
-# https://www.serverless.com/framework/docs/providers/aws/guide/variables#reference-variables-using-the-ssm-parameter-store
-variablesResolutionMode: 20210326
-
 custom:
   # https://github.com/amplify-education/serverless-domain-manager
   # 1. 事前に作成した証明書(by Terraform)を使用してカスタムドメイン(domainName)作成


### PR DESCRIPTION
## Commits

- [Remove configValidationMode: error because it became the default](https://github.com/zuka-e/laravel-react-task-spa/commit/d509445de7222beed24a615b40944e73776120da)
  see: https://www.serverless.com/framework/docs/deprecations#configvalidationmode-error-will-be-new-default
- [Remove no longer required variablesResolutionMode: 20210326](https://github.com/zuka-e/laravel-react-task-spa/commit/15b9c72aa16380d1cbbee0042d81f080108944b4) 
  see: https://www.serverless.com/framework/docs/providers/aws/guide/variables#exporting-a-function
- [Remove the old algorithm lambdaHashingVersion: 20201221](https://github.com/zuka-e/laravel-react-task-spa/commit/c50431918d4ad36558e0f22eae5d9c260fbb8c22) 
  see: https://www.serverless.com/framework/docs/guides/upgrading-v3#lambda-hashing-algorithm
- [Show deprecated details in running serverless](https://github.com/zuka-e/laravel-react-task-spa/commit/fb23e7affbd079cf6f02bb38730140147dec9086)
  see:  https://www.serverless.com/framework/docs/deprecations#notification-mode