### PR TITLE
Fix not running MySQL container and an issue dependency directories aren't created

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -30,16 +30,6 @@ services:
     depends_on:
       - mysql
       - redis
-  mysql.test:
-    image: 'mysql:8.0'
-    ports:
-      - '${FORWARD_TEST_DB_PORT:-3307}:3306'
-    environment:
-      MYSQL_ROOT_HOST: '%'
-      MYSQL_DATABASE: '${DB_DATABASE}'
-      MYSQL_ALLOW_EMPTY_PASSWORD: 1
-    networks:
-      - sail
   mysql:
     image: 'mysql:8.0'
     ports:
@@ -56,6 +46,16 @@ services:
       test: ['CMD', 'mysqladmin', 'ping', '-p${DB_PASSWORD}']
       retries: 3
       timeout: 5s
+  mysql.test:
+    image: 'mysql:8.0'
+    ports:
+      - '${FORWARD_TEST_DB_PORT:-3307}:3306'
+    environment:
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_DATABASE: '${DB_DATABASE}'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    networks:
+      - sail
   redis:
     image: 'redis:alpine'
     ports:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -35,11 +35,9 @@ services:
     ports:
       - '${FORWARD_TEST_DB_PORT:-3307}:3306'
     environment:
-      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: '${DB_DATABASE}'
-      MYSQL_USER: '${DB_USERNAME}'
-      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 1
     networks:
       - sail
   mysql:
@@ -47,11 +45,8 @@ services:
     ports:
       - '${FORWARD_DB_PORT:-3306}:3306'
     environment:
-      MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ROOT_HOST: '%'
       MYSQL_DATABASE: '${DB_DATABASE}'
-      MYSQL_USER: '${DB_USERNAME}'
-      MYSQL_PASSWORD: '${DB_PASSWORD}'
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     volumes:
       - 'sail-mysql:/var/lib/mysql'

--- a/backend/docker/8.1/start-container
+++ b/backend/docker/8.1/start-container
@@ -10,8 +10,10 @@ fi
 
 chmod -R ugo+rw /.composer
 
-mkdir -p $BACKEND_DIR/{node_modules,vendor} \
-    && chown -R sail:sail $BACKEND_DIR/{node_modules,vendor}
+# Relative path to `working_dir` in `docker-compose.yml` is used.
+# Absolute path, ${PROJECT_DIR}/${BACKEND_DIR}/, can also be used.
+mkdir -p node_modules vendor \
+    && chown -R sail:sail node_modules vendor
 
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"


### PR DESCRIPTION
## Summary

When running `sail up` the following error occurred.

```
MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD
```

In accordance with the message,  Remove `MYSQL_USER`, `MYSQL_ROOT_PASSWORD`, and `MYSQL_PASSWORD`.

Next problem, dependency directories not created, is due to the wrong path designation, then fix it.
Unless there are the directories when creating the container, that owner become root.