### PR TITLE
Fix an issue that the asset URL is wrong

### DIFF
--- a/backend/.env.dev
+++ b/backend/.env.dev
@@ -9,6 +9,8 @@ APP_ENV=production
 APP_DEBUG=false
 # APP_URL=(Serverless SSM)
 
+# MIX_ASSET_URL=(Serverless SSM)
+
 API_ROUTE_PREFIX=/api/
 API_VERSION=v1
 

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -53,7 +53,11 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    // https://laravel.com/docs/9.x/helpers#method-asset
     'asset_url' => env('ASSET_URL', null),
+
+    // https://laravel.com/docs/9.x/mix#custom-mix-base-urls
+    'mix_url' => env('MIX_ASSET_URL', null),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -65,6 +65,7 @@ provider:
     APP_KEY: ${env:APP_KEY}
     APP_DEBUG: ${env:APP_DEBUG}
     APP_URL: https://api.${self:custom.domainName}
+    MIX_ASSET_URL: https://${ssm:/${self:custom.ssmPrefix}/S3_BUCKET}.s3.amazonaws.com/public
     LOG_CHANNEL: ${env:LOG_CHANNEL, "stderr"}
     LOG_LEVEL: ${env:LOG_LEVEL}
     DB_CONNECTION: ${env:DB_CONNECTION}


### PR DESCRIPTION
## Problem

S3 asset in't reflected due to deleting a necessary environment variable at the following commit.

- #150 
  - [Make env vars in serverless.yml only those existing in .env](https://github.com/zuka-e/laravel-react-task-spa/pull/150/commits/49a2ae8726be9646d0c16200ebee29d4d2055a69)


Telescope uses the Mix asset URL in `vendor/laravel/telescope/resources/views/layout.blade.php`.

## References

- https://laravel.com/docs/9.x/mix#custom-mix-base-urls