### PR TITLE
Suspend the CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,10 @@
 name: Continuous Deployment
 
 on:
-  push:
-    branches:
-      - development
-  pull_request:
+  # push:
+  #   branches:
+  #     - development
+  # pull_request:
 
 env:
   PROJECT: Miwataru


### PR DESCRIPTION
## Updated

- Removed `Build Shared Infrastructure` from `Protect matching branches`

---

![スクリーンショット 2022-07-10 1 41 53](https://user-images.githubusercontent.com/52391918/178115035-72f1e9b1-1caf-4920-8bb1-ba76c3c8d094.jpg)

