### PR TITLE
Make HTTP error handling more easier

### DIFF
--- a/backend/app/Exceptions/Handler.php
+++ b/backend/app/Exceptions/Handler.php
@@ -3,10 +3,29 @@
 namespace App\Exceptions;
 
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Support\Arr;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Throwable;
 
+/** @see https://laravel.com/docs/9.x/errors */
 class Handler extends ExceptionHandler
 {
+    /**
+     * The default error messages corresponding to each error code.
+     *
+     * @var array<int, string>
+     */
+    public const HTTP_ERRORS = [
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        419 => 'Page Expired',
+        429 => 'Too Many Requests',
+        500 => 'Internal Server Error',
+        503 => 'Service Unavailable',
+    ];
+
     /**
      * A list of the exception types that are not reported.
      *
@@ -37,6 +56,37 @@ class Handler extends ExceptionHandler
         $this->reportable(function (Throwable $e) {
             //
         });
+    }
+
+    /**
+     * Convert the given exception to an array.
+     *
+     * @param  \Throwable  $e
+     * @return array
+     */
+    protected function convertExceptionToArray(Throwable $e)
+    {
+        // If no error message is specified, the default value will be set.
+        // For example, `abort(403)` is handled like `abort(403, 'Forbidden')`.
+        $message =
+            $e instanceof HttpExceptionInterface
+                ? ($e->getMessage() ?:
+                self::HTTP_ERRORS[$e->getStatusCode()] ?? '')
+                : 'Server Error';
+
+        return config('app.debug')
+            ? [
+                'message' => $message,
+                'exception' => get_class($e),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+                'trace' => collect($e->getTrace())
+                    ->map(fn($trace) => Arr::except($trace, ['args']))
+                    ->all(),
+            ]
+            : [
+                'message' => $message,
+            ];
     }
 
     /**

--- a/backend/app/Exceptions/Handler.php
+++ b/backend/app/Exceptions/Handler.php
@@ -38,4 +38,17 @@ class Handler extends ExceptionHandler
             //
         });
     }
+
+    /**
+     * Determine if the exception handler response should be JSON.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Throwable  $e
+     * @return bool
+     */
+    protected function shouldReturnJson($request, Throwable $e)
+    {
+        // Only JSON should be returned, as this Laravel app is used as API server.
+        return true;
+    }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -60,20 +60,3 @@ Route::group(
             ->scoped();
     },
 );
-
-/*
-|--------------------------------------------------------------
-| Not Found
-|--------------------------------------------------------------
-*/
-Route::any('/{any?}', function ($any = null) {
-    return response()->json(
-        [
-            'error' => [
-                'title' => '404 Not Found',
-                'message' => 'The requested URL was not found',
-            ],
-        ],
-        404,
-    );
-})->where('any', '.*');


### PR DESCRIPTION
## Summary

- 404 Not Found error and other HTTP errors are returned as JSON.
- Add the default error message of HTTP exceptions (`abort()`)